### PR TITLE
Fix to IPv4 UDP ~100% message loss and heap crash

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -193,7 +193,7 @@ lw_addr lw_addr_clone (lw_addr ctx)
 
    memcpy (addr->service, ctx->service, sizeof (ctx->service));
 
-   addr->hostname = addr->hostname_to_free = ctx->hostname;
+   addr->hostname = addr->hostname_to_free = _strdup(ctx->hostname);
 
    return addr;
 }
@@ -421,7 +421,7 @@ static lw_bool sockaddr_equal (struct sockaddr * a, struct sockaddr * b)
 
       return !memcmp (&((struct sockaddr_in *) a)->sin_addr,
                       &((struct sockaddr_in *) b)->sin_addr,
-                      sizeof (struct in6_addr));
+                      sizeof (struct in_addr));
    }
 
    return lw_false;


### PR DESCRIPTION
Two changes.

1. No use of strdup when using lw_addr_clone, so the address is freed when referred to in the new instance (causing a heap crash.
2. Second, literally a single character causing all UDP messages to mismatch the filter - `in_addr6` was used instead of `inaddr` in IPv4 address comparisons.
If you were using calloc, you miss the second problem, as the IPv6 part is zero'd in both. I missed it that way in my Bluewing port.